### PR TITLE
Updated the sample code to work with EF 2.0

### DIFF
--- a/SourceCode_Chapter01/SpyStore.DAL/EF/MyExecutionStrategy.cs
+++ b/SourceCode_Chapter01/SpyStore.DAL/EF/MyExecutionStrategy.cs
@@ -1,16 +1,28 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore;
 
 namespace SpyStore.DAL.EF
 {
     public class MyExecutionStrategy : ExecutionStrategy
     {
-        public MyExecutionStrategy(ExecutionStrategyContext context) :
-            base(context, ExecutionStrategy.DefaultMaxRetryCount, ExecutionStrategy.DefaultMaxDelay)
+        public MyExecutionStrategy(DbContext context) :
+            this(context, DefaultMaxRetryCount, DefaultMaxDelay)
         {
         }
 
-        public MyExecutionStrategy(ExecutionStrategyContext context, int maxRetryCount, TimeSpan maxRetryDelay) : base(context, maxRetryCount, maxRetryDelay)
+        public MyExecutionStrategy(DbContext context, int maxRetryCount, TimeSpan maxRetryDelay) :
+            base(context, maxRetryCount, maxRetryDelay)
+        {
+        }
+
+        public MyExecutionStrategy(ExecutionStrategyDependencies dependencies) :
+            this(dependencies, DefaultMaxRetryCount, DefaultMaxDelay)
+        {
+        }
+
+        public MyExecutionStrategy(ExecutionStrategyDependencies dependencies, int maxRetryCount, TimeSpan maxRetryDelay) :
+            base(dependencies, maxRetryCount, maxRetryDelay)
         {
         }
 


### PR DESCRIPTION
I ran into the same problem as another person who asked the question on Stack Overflow.  Here is that exchange.  The proffered solution works.

Question from  Shane Blume --

I'm reading "Building Web Applications with Visual Studio 2017" (by Philip Japikse, Kevin Grossnicklaus, and Ben Dewey) and am getting stuck. When trying to create a class for a custome execution strategy with Entity Framework Core I get error CR0246 "The type or namespace name 'ExecutionStrategyContext' could not be found (are you missing a using directive or assembly reference?)"

The text only states that only System and Microsoft.EntityFrameworkCore.Storage are required references. The EF Core 2.0 documentation seems to match the text but I cannot get the error to go away.

Note: The book uses Core and EF 1.1 whereas I am using 2.0. But I don't see anything in any documentation that hints at this being the issue.

Ivan Stoev response is below. The updated code is from him . ---

I can't provide a documentation link because at this time the related EF Core API documentation is not updated yet, but in v2.0 the ExecutionStrategyContext class has been replaced with ExecutionStrategyDependencies and the ExecutionStrategy class now has the following constructors:

protected ExecutionStrategy(DbContext context, int maxRetryCount, TimeSpan maxRetryDelay);

protected ExecutionStrategy(ExecutionStrategyDependencies dependencies, int maxRetryCount, TimeSpan maxRetryDelay);
According to that, the updated sample should be something like this: